### PR TITLE
Fix remaining unit-test gaps and complete pending app tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -12,6 +16,7 @@ jobs:
   quality-gate:
     name: quality-gate
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,9 +39,16 @@ jobs:
       - name: Run build
         run: npm run build
 
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage
+
   e2e-smoke:
     name: e2e-smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: quality-gate
     steps:
       - name: Checkout repository

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,7 +5,7 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; img-src 'self' data: https://upload.wikimedia.org https://*.wikimedia.org; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https://de.wikipedia.org https://commons.wikimedia.org https://upload.wikimedia.org; font-src 'self' data: https://fonts.gstatic.com; form-action 'self'" always;
+    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; img-src 'self' data: https://upload.wikimedia.org https://commons.wikimedia.org; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https://de.wikipedia.org https://en.wikipedia.org https://commons.wikimedia.org https://upload.wikimedia.org; font-src 'self' data: https://fonts.gstatic.com; form-action 'self'" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/e2e/support/mockBirdnet.ts
+++ b/e2e/support/mockBirdnet.ts
@@ -18,8 +18,14 @@ const offsetDays = (base: Date, days: number): Date => {
   return new Date(base.valueOf() + days * 24 * 60 * 60_000)
 }
 
-const buildDetections = (): MockDetectionRecord[] => {
+const REFERENCE_NOW = (() => {
   const now = new Date()
+  now.setUTCHours(12, 0, 0, 0)
+  return now
+})()
+
+const buildDetections = (): MockDetectionRecord[] => {
+  const now = new Date(REFERENCE_NOW)
 
   return [
     {
@@ -144,7 +150,7 @@ const paginate = <T>(items: T[], limit: number, offset: number): T[] => {
 }
 
 const buildSummary30d = (detections: MockDetectionRecord[]) => {
-  const now = new Date()
+  const now = new Date(REFERENCE_NOW)
   const windowStart = new Date(now)
   windowStart.setDate(windowStart.getDate() - 29)
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/bird-favicon.svg" />

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -17,7 +17,7 @@ const RECENT_REFRESH_MS = Number(process.env.RECENT_REFRESH_MS ?? `${15 * 60_000
 
 const securityHeaders = {
   'content-security-policy':
-    "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; img-src 'self' data: https://upload.wikimedia.org https://*.wikimedia.org; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https://de.wikipedia.org https://commons.wikimedia.org https://upload.wikimedia.org; font-src 'self' data: https://fonts.gstatic.com; form-action 'self'",
+    "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; img-src 'self' data: https://upload.wikimedia.org https://commons.wikimedia.org; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https://de.wikipedia.org https://en.wikipedia.org https://commons.wikimedia.org https://upload.wikimedia.org; font-src 'self' data: https://fonts.gstatic.com; form-action 'self'",
   'x-content-type-options': 'nosniff',
   'x-frame-options': 'DENY',
   'referrer-policy': 'strict-origin-when-cross-origin',
@@ -30,7 +30,8 @@ const summaryCache = {
 }
 
 const INTERNAL_PROXY_HEADER = 'x-internal-summary-proxy'
-const INTERNAL_PROXY_VALUE = process.env.INTERNAL_PROXY_VALUE ?? '1'
+const INTERNAL_PROXY_VALUE =
+  process.env.INTERNAL_PROXY_VALUE ?? (globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`)
 
 const toIsoDate = (value) => value.toISOString().slice(0, 10)
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -8,6 +8,7 @@ import { renderWithQuery } from './test/renderWithQuery'
 const mocks = vi.hoisted(() => {
   return {
     getPhotoAttributionRecords: vi.fn<() => PhotoAttributionRecord[]>(() => []),
+    throwLandingView: false,
   }
 })
 
@@ -23,20 +24,28 @@ vi.mock('./features/landing/LandingView', () => ({
     onAttributionOpen: () => void
     onSpeciesSelect: (species: { commonName: string; scientificName: string }) => void
   }) => (
-    <div>
-      Landing View
-      <button
-        onClick={() => {
-          onSpeciesSelect({ commonName: 'Barn Owl', scientificName: 'Tyto alba' })
-        }}
-        type="button"
-      >
-        Select Barn Owl
-      </button>
-      <button onClick={onAttributionOpen} type="button">
-        Open Attribution From Landing
-      </button>
-    </div>
+    (() => {
+      if (mocks.throwLandingView) {
+        throw new Error('landing exploded')
+      }
+
+      return (
+        <div>
+          Landing View
+          <button
+            onClick={() => {
+              onSpeciesSelect({ commonName: 'Barn Owl', scientificName: 'Tyto alba' })
+            }}
+            type="button"
+          >
+            Select Barn Owl
+          </button>
+          <button onClick={onAttributionOpen} type="button">
+            Open Attribution From Landing
+          </button>
+        </div>
+      )
+    })()
   ),
 }))
 
@@ -133,6 +142,7 @@ describe('App navigation and URL state', () => {
   beforeEach(() => {
     mocks.getPhotoAttributionRecords.mockReset()
     mocks.getPhotoAttributionRecords.mockReturnValue([])
+    mocks.throwLandingView = false
     window.localStorage.clear()
     window.history.replaceState(null, '', '/')
   })
@@ -269,5 +279,49 @@ describe('App navigation and URL state', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: /Schlie/ }))
     expect(screen.queryByRole('heading', { name: 'Wikimedia/Wikipedia Lizenzen' })).toBeNull()
+  })
+
+  it('supports modal keyboard controls and focus trap', async () => {
+    mocks.getPhotoAttributionRecords.mockReturnValue([
+      {
+        commonName: 'Amsel',
+        scientificName: 'Turdus merula',
+        hasImage: true,
+        sourceUrl: 'https://example.test/source',
+        author: 'Tester',
+        license: 'CC BY-SA 4.0',
+        licenseUrl: 'https://example.test/license',
+      },
+    ])
+
+    renderWithQuery(<App />)
+    fireEvent.click(screen.getByRole('button', { name: 'Bildnachweise' }))
+
+    const closeButton = screen.getByRole('button', { name: /Schlie/ })
+    await waitFor(() => {
+      expect(closeButton).toHaveFocus()
+    })
+
+    fireEvent.keyDown(window, { key: 'Tab', shiftKey: true })
+    expect(screen.getByRole('link', { name: 'Wikimedia-Quelle' })).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: 'Tab' })
+    expect(closeButton).toHaveFocus()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: 'Wikimedia/Wikipedia Lizenzen' })).toBeNull()
+    })
+  })
+
+  it('shows error boundary fallback when a view throws', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.throwLandingView = true
+
+    renderWithQuery(<App />)
+
+    expect(screen.getByText('Etwas ist schiefgelaufen')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Seite neu laden' })).toBeInTheDocument()
+    expect(errorSpy).toHaveBeenCalled()
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { getPhotoAttributionRecords } from './api/birdImages'
+import ErrorBoundary from './components/ErrorBoundary'
 import { siteConfig } from './config/site'
 import { t } from './i18n'
 import DetectionsView from './features/detections/DetectionsView'
@@ -25,13 +26,21 @@ type AppRouteState = {
 }
 
 type ThemeMode = 'light' | 'dark'
+type NavItem = {
+  view: MainView
+  label: string
+}
 
 const THEME_STORAGE_KEY = 'birdnet-showoff-theme'
 
 const getInitialTheme = (): ThemeMode => {
-  const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
-  if (stored === 'light' || stored === 'dark') {
-    return stored
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+    if (stored === 'light' || stored === 'dark') {
+      return stored
+    }
+  } catch {
+    // no-op (storage may be unavailable in restricted contexts)
   }
 
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
@@ -91,7 +100,7 @@ const createRoute = (state: AppRouteState): string => {
 }
 
 const App = () => {
-  const initialState = parseRouteState()
+  const [initialState] = useState<AppRouteState>(() => parseRouteState())
   const [view, setView] = useState<AppView>(initialState.view)
   const [lastMainView, setLastMainView] = useState<'today' | 'archive' | 'rarity' | 'stats'>(
     initialState.lastMainView,
@@ -104,6 +113,8 @@ const App = () => {
   const [showScrollTop, setShowScrollTop] = useState(false)
   const [isAttributionOpen, setIsAttributionOpen] = useState(false)
   const [, setAttributionVersion] = useState(0)
+  const attributionDialogRef = useRef<HTMLDivElement | null>(null)
+  const attributionCloseRef = useRef<HTMLButtonElement | null>(null)
 
   useBackgroundCacheWarmer(view === 'landing' || view === 'today')
 
@@ -118,10 +129,8 @@ const App = () => {
   }
 
   useEffect(() => {
-    const initialRoute = parseRouteState()
-    const nextUrl = createRoute(initialRoute)
-    window.history.replaceState(null, '', nextUrl)
-  }, [])
+    window.history.replaceState(null, '', createRoute(initialState))
+  }, [initialState])
 
   useEffect(() => {
     const onAttributionUpdate = () => {
@@ -236,7 +245,65 @@ const App = () => {
     window.scrollTo({ top: 0 })
   }
 
+
+  useEffect(() => {
+    if (!isAttributionOpen) {
+      return
+    }
+
+    attributionCloseRef.current?.focus()
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setIsAttributionOpen(false)
+        return
+      }
+
+      if (event.key !== 'Tab') {
+        return
+      }
+
+      const dialog = attributionDialogRef.current
+      if (!dialog) {
+        return
+      }
+
+      const focusables = dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+      )
+
+      if (focusables.length === 0) {
+        return
+      }
+
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      const active = document.activeElement
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [isAttributionOpen])
+
   const activeNavigationView = view
+  const navItems: NavItem[] = [
+    { view: 'landing', label: t('nav.live') },
+    { view: 'today', label: t('nav.today') },
+    { view: 'archive', label: t('nav.archive') },
+    { view: 'rarity', label: t('nav.highlights') },
+    { view: 'stats', label: t('nav.stats') },
+  ]
   const openAttribution = () => {
     setIsAttributionOpen(true)
   }
@@ -304,65 +371,43 @@ const App = () => {
                 <span className="hidden sm:inline">{theme === 'dark' ? t('theme.light') : t('theme.dark')}</span>
               </span>
             </button>
-            <button
-              className={`inline-flex h-9 shrink-0 items-center rounded-xl border px-4 py-2 text-[0.65rem] transition ${
-                activeNavigationView === 'landing'
-                  ? 'border-slate-200 bg-white text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100'
-                  : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300'
-              }`}
-              onClick={() => handleViewChange('landing')}
-              type="button"
-            >
-              {t('nav.live')}
-            </button>
-            <button
-              className={`inline-flex h-9 shrink-0 items-center rounded-xl border px-4 py-2 text-[0.65rem] transition ${
-                activeNavigationView === 'today'
-                  ? 'border-slate-200 bg-white text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100'
-                  : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300'
-              }`}
-              onClick={() => handleViewChange('today')}
-              type="button"
-            >
-              {t('nav.today')}
-            </button>
-            <button
-              className={`inline-flex h-9 shrink-0 items-center rounded-xl border px-4 py-2 text-[0.65rem] transition ${
-                activeNavigationView === 'archive'
-                  ? 'border-slate-200 bg-white text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100'
-                  : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300'
-              }`}
-              onClick={() => handleViewChange('archive')}
-              type="button"
-            >
-              {t('nav.archive')}
-            </button>
-            <button
-              className={`inline-flex h-9 shrink-0 items-center rounded-xl border px-4 py-2 text-[0.65rem] transition ${
-                activeNavigationView === 'rarity'
-                  ? 'border-slate-200 bg-white text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100'
-                  : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300'
-              }`}
-              onClick={() => handleViewChange('rarity')}
-              type="button"
-            >
-              {t('nav.highlights')}
-            </button>
-            <button
-              className={`inline-flex h-9 shrink-0 items-center rounded-xl border px-4 py-2 text-[0.65rem] transition ${
-                activeNavigationView === 'stats'
-                  ? 'border-slate-200 bg-white text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100'
-                  : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300'
-              }`}
-              onClick={() => handleViewChange('stats')}
-              type="button"
-            >
-              {t('nav.stats')}
-            </button>
+            {navItems.map((item) => (
+              <button
+                className={`inline-flex h-9 shrink-0 items-center rounded-xl border px-4 py-2 text-[0.65rem] transition ${
+                  activeNavigationView === item.view
+                    ? 'border-slate-200 bg-white text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100'
+                    : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300'
+                }`}
+                key={item.view}
+                onClick={() => handleViewChange(item.view)}
+                type="button"
+              >
+                {item.label}
+              </button>
+            ))}
           </div>
         </div>
       </header>
 
+      <ErrorBoundary
+        fallback={
+          <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-4 py-5 sm:gap-10 sm:px-6 sm:py-10">
+            <section className="rounded-2xl border border-rose-200 bg-rose-50 p-6 text-center dark:border-rose-700/70 dark:bg-rose-900/20">
+              <h2 className="text-lg font-semibold text-rose-700 dark:text-rose-200">{t('errorBoundary.heading')}</h2>
+              <p className="mt-2 text-sm text-rose-700/90 dark:text-rose-200/90">{t('errorBoundary.description')}</p>
+              <button
+                className="mt-4 rounded-xl bg-rose-600 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white transition hover:bg-rose-500"
+                onClick={() => {
+                  window.location.reload()
+                }}
+                type="button"
+              >
+                {t('errorBoundary.reload')}
+              </button>
+            </section>
+          </main>
+        }
+      >
       <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-4 py-5 sm:gap-10 sm:px-6 sm:py-10">
         {view === 'landing' ? (
           <LandingView
@@ -409,6 +454,7 @@ const App = () => {
           </button>
         </p>
       </main>
+      </ErrorBoundary>
 
       {showScrollTop ? (
         <button
@@ -436,18 +482,25 @@ const App = () => {
 
       {isAttributionOpen ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 px-4 py-6">
-          <div className="max-h-[85vh] w-full max-w-3xl overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl dark:border-slate-700 dark:bg-slate-900">
+          <div
+            aria-labelledby="attribution-heading"
+            aria-modal="true"
+            className="max-h-[85vh] w-full max-w-3xl overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl dark:border-slate-700 dark:bg-slate-900"
+            ref={attributionDialogRef}
+            role="dialog"
+          >
             <div className="flex items-center justify-between border-b border-slate-200 px-5 py-4 dark:border-slate-700">
               <div>
                 <p className="text-xs uppercase tracking-[0.2em] text-slate-400 dark:text-slate-400">
                   {t('attribution.modalLabel')}
                 </p>
-                <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100" id="attribution-heading">
                   {t('attribution.modalHeading')}
                 </h2>
               </div>
               <button
                 className="rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 transition hover:border-slate-300 hover:bg-slate-200 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-600 dark:hover:bg-slate-700"
+                ref={attributionCloseRef}
                 onClick={() => {
                   setIsAttributionOpen(false)
                 }}

--- a/src/api/apiClient.test.ts
+++ b/src/api/apiClient.test.ts
@@ -34,6 +34,17 @@ describe('apiClient helpers', () => {
     expect(buildApiUrl('https://other.example/path', query)).toBe('https://other.example/path?limit=10')
   })
 
+  it('returns empty base URL for missing, invalid, and non-http env values', () => {
+    vi.stubEnv('VITE_BIRDNET_API_BASE_URL', '')
+    expect(getApiBaseUrl()).toBe('')
+
+    vi.stubEnv('VITE_BIRDNET_API_BASE_URL', 'http://[::1')
+    expect(getApiBaseUrl()).toBe('')
+
+    vi.stubEnv('VITE_BIRDNET_API_BASE_URL', 'javascript:alert(1)')
+    expect(getApiBaseUrl()).toBe('')
+  })
+
   it('returns JSON payload when request succeeds', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
     vi.stubGlobal('fetch', fetchMock)

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -69,6 +69,15 @@ export const getApiBaseUrl = (): string => {
     return ''
   }
 
+  try {
+    const url = new URL(baseUrl, window.location.origin)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return ''
+    }
+  } catch {
+    return ''
+  }
+
   return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
 }
 

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import ErrorBoundary from './ErrorBoundary'
+import { renderWithQuery } from '../test/renderWithQuery'
+
+const Boom = () => {
+  throw new Error('boom')
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error occurs', () => {
+    renderWithQuery(
+      <ErrorBoundary fallback={<div>Fallback</div>}>
+        <div>Safe child</div>
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText('Safe child')).toBeInTheDocument()
+  })
+
+  it('renders fallback when child throws', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    renderWithQuery(
+      <ErrorBoundary fallback={<button type="button">Try again</button>}>
+        <Boom />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+    expect(errorSpy).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+  })
+})

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import { type ErrorInfo, type ReactNode, Component } from 'react'
+
+type ErrorBoundaryProps = {
+  children: ReactNode
+  fallback: ReactNode
+}
+
+type ErrorBoundaryState = {
+  hasError: boolean
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Application render failed', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/features/landing/LandingView.tsx
+++ b/src/features/landing/LandingView.tsx
@@ -78,7 +78,7 @@ const LiveHighlightCard = ({
     : t('attribution.showAttribution')
 
   return (
-    <article
+    <div
       className={`group flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/80 bg-slate-50 shadow-sm dark:border-slate-700/80 dark:bg-slate-800 ${isInteractive ? 'cursor-pointer transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md dark:hover:border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300' : ''}`}
       onClick={isInteractive ? handleSelect : undefined}
       onKeyDown={
@@ -158,7 +158,7 @@ const LiveHighlightCard = ({
         </div>
         <p className="clamp-1 text-[0.7rem] text-slate-500 dark:text-slate-400 sm:text-xs">{scientificName}</p>
       </div>
-    </article>
+    </div>
   )
 }
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -31,7 +31,7 @@ export function t(key: TranslationKey, params?: Record<string, string | number>)
 
   if (params) {
     for (const [paramKey, paramValue] of Object.entries(params)) {
-      value = value.replace(new RegExp(`\\{${paramKey}\\}`, 'g'), String(paramValue))
+      value = value.split(`{${paramKey}}`).join(String(paramValue))
     }
   }
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -4,7 +4,6 @@
   "nav.archive": "Archiv",
   "nav.highlights": "Highlights",
   "nav.stats": "Statistik",
-
   "stats.sectionLabel": "Übersicht",
   "stats.heading": "Statistiken",
   "stats.description": "Vorberechnete Gesamtstatistik ueber alle verarbeiteten Erkennungen.",
@@ -19,13 +18,11 @@
   "stats.loading": "Statistiken werden geladen...",
   "stats.loadingProgress": "Wird geladen... {count} Erkennungen bisher",
   "stats.sampleNote": "Basiert auf {count} insgesamt verarbeiteten Erkennungen.",
-
   "theme.activateLight": "Helles Design aktivieren",
   "theme.activateDark": "Dunkles Design aktivieren",
   "theme.light": "Hell",
   "theme.dark": "Dunkel",
   "scrollTop.label": "Nach oben scrollen",
-
   "common.close": "Schließen",
   "common.refresh": "Aktualisieren",
   "common.retry": "Erneut versuchen",
@@ -42,7 +39,6 @@
   "common.detectionPlural": "Sichtungen",
   "common.confidence": "Sicherheit {value}",
   "common.timezone": "Zeitzone: {zone}",
-
   "live.sectionLabel": "Live-Highlights",
   "live.heading": "Live",
   "live.autoRefresh": "Automatisch alle 30 Sekunden aktualisiert.",
@@ -51,7 +47,6 @@
   "live.statusMinutesAgo": "Vor {minutes} min",
   "live.statusHoursAgo": "Vor {hours} h",
   "live.noDetections": "Noch keine aktuellen Arten erkannt.",
-
   "today.sectionLabel": "Heute",
   "today.heading": "Heutige Erkennungen",
   "today.lastUpdated": "Zuletzt aktualisiert: {time}",
@@ -69,7 +64,6 @@
   "today.noFilteredList": "Noch keine Erkennungen passen zu diesem Filter.",
   "today.noDetectionsList": "Noch keine Erkennungen gefunden.",
   "today.loading": "Erkennungen von BirdNET-Go werden geladen...",
-
   "archive.sectionLabel": "Archiv",
   "archive.heading": "Erkennungen im Datumsbereich",
   "archive.description": "Erkennungen ausserhalb von heute anzeigen.",
@@ -87,7 +81,6 @@
   "archive.quickToday": "Heute",
   "archive.quickWeek": "Letzte 7 Tage",
   "archive.quickMonth": "Letzte 30 Tage",
-
   "rarity.periodLabel": "Zeitraum (fix)",
   "rarity.periodHeading": "Letzte 30 Tage",
   "rarity.periodDescription": "Der Zeitraum ist für bessere Geschwindigkeit fest auf 30 Tage gesetzt.",
@@ -103,7 +96,6 @@
   "rarity.matchCount": "{count} Treffer",
   "rarity.noHighlights": "Keine besonderen Arten in diesem Zeitraum gefunden.",
   "rarity.lastSeen": "Zuletzt gesehen: {date}",
-
   "notable.sectionLabel": "Lokale besondere Sichtungen",
   "notable.heading": "Besondere Arten im Zeitraum",
   "notable.curatedFor": "Kuratiert fuer {region} · {range}",
@@ -111,7 +103,6 @@
   "notable.noResults": "Noch keine besonderen Sichtungen in diesem Zeitraum gefunden.",
   "notable.whyNotable": "Warum bemerkenswert: {reasons}",
   "notable.lastSeen": "Zuletzt gesehen {date}",
-
   "species.sectionLabel": "Art-Detail",
   "species.familyLabel": "Familie",
   "species.familyDescription": "Weitere erkannte Arten derselben Familie.",
@@ -127,14 +118,12 @@
   "species.rarityLabel": "Seltenheit: {value}",
   "species.familyBadge": "Familie: {value}",
   "species.fallbackDescription": "{commonName} ({scientificName}) ist an diesem Standort erfasst. Eine redaktionelle Kurzbeschreibung wird noch ergaenzt.",
-
   "rarity.veryRare": "sehr selten",
   "rarity.rare": "selten",
   "rarity.uncommon": "unregelmaessig",
   "rarity.common": "haeufig",
   "rarity.veryCommon": "sehr haeufig",
   "rarity.unknown": "unbekannt",
-
   "attribution.footer": "Bilder stammen aus Wikipedia/Wikimedia. Es gelten die jeweils dort angegebenen Lizenzbedingungen.",
   "attribution.linkLabel": "Bildnachweise",
   "attribution.modalLabel": "Bildnachweise",
@@ -155,7 +144,6 @@
   "attribution.wikimediaLink": "Wikimedia/Wikipedia",
   "attribution.licenseText": "Lizenztext",
   "attribution.photoOf": "Foto von {name}",
-
   "error.accessDenied": "Zugriff auf {service} wurde verweigert.",
   "error.notFound": "{service} konnte die angeforderten Daten nicht finden.",
   "error.tooManyRequests": "Zu viele Anfragen an {service}. Bitte in kurzem Abstand erneut versuchen.",
@@ -168,5 +156,8 @@
   "error.archiveLoad": "Archiv-Erkennungen konnten nicht geladen werden",
   "error.speciesLoad": "Art-Erkennungen konnten nicht geladen werden.",
   "error.speciesPhotoLoad": "Artenfoto konnte nicht geladen werden",
-  "error.familyLoad": "Arten dieser Familie konnten nicht geladen werden."
+  "error.familyLoad": "Arten dieser Familie konnten nicht geladen werden.",
+  "errorBoundary.heading": "Etwas ist schiefgelaufen",
+  "errorBoundary.description": "Beim Laden dieser Ansicht ist ein unerwarteter Fehler aufgetreten.",
+  "errorBoundary.reload": "Seite neu laden"
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -4,7 +4,6 @@
   "nav.archive": "Archive",
   "nav.highlights": "Highlights",
   "nav.stats": "Statistics",
-
   "stats.sectionLabel": "Overview",
   "stats.heading": "Statistics",
   "stats.description": "Precomputed global statistics across all processed detections.",
@@ -19,13 +18,11 @@
   "stats.loading": "Loading statistics...",
   "stats.loadingProgress": "Loading... {count} detections so far",
   "stats.sampleNote": "Based on {count} total processed detections.",
-
   "theme.activateLight": "Activate Light Theme",
   "theme.activateDark": "Activate Dark Theme",
   "theme.light": "Light",
   "theme.dark": "Dark",
   "scrollTop.label": "Scroll to top",
-
   "common.close": "Close",
   "common.refresh": "Refresh",
   "common.retry": "Retry",
@@ -42,7 +39,6 @@
   "common.detectionPlural": "Detections",
   "common.confidence": "Confidence {value}",
   "common.timezone": "Timezone: {zone}",
-
   "live.sectionLabel": "Live Highlights",
   "live.heading": "Live",
   "live.autoRefresh": "Auto-refreshes every 30 seconds.",
@@ -51,7 +47,6 @@
   "live.statusMinutesAgo": "{minutes} min ago",
   "live.statusHoursAgo": "{hours} h ago",
   "live.noDetections": "No detections yet.",
-
   "today.sectionLabel": "Today",
   "today.heading": "Today's Detections",
   "today.lastUpdated": "Last updated: {time}",
@@ -69,7 +64,6 @@
   "today.noFilteredList": "No detections match this filter.",
   "today.noDetectionsList": "No detections found.",
   "today.loading": "Loading detections from BirdNET-Go...",
-
   "archive.sectionLabel": "Archive",
   "archive.heading": "Detections in Date Range",
   "archive.description": "View detections outside of today.",
@@ -87,7 +81,6 @@
   "archive.quickToday": "Today",
   "archive.quickWeek": "Last 7 Days",
   "archive.quickMonth": "Last 30 Days",
-
   "rarity.periodLabel": "Period (Fixed)",
   "rarity.periodHeading": "Last 30 Days",
   "rarity.periodDescription": "The period is fixed to 30 days for better performance.",
@@ -103,7 +96,6 @@
   "rarity.matchCount": "{count} matches",
   "rarity.noHighlights": "No notable species found in this period.",
   "rarity.lastSeen": "Last seen: {date}",
-
   "notable.sectionLabel": "Local Notable Sightings",
   "notable.heading": "Notable Species in Range",
   "notable.curatedFor": "Curated for {region} · {range}",
@@ -111,7 +103,6 @@
   "notable.noResults": "No notable sightings found in this period.",
   "notable.whyNotable": "Why notable: {reasons}",
   "notable.lastSeen": "Last seen {date}",
-
   "species.sectionLabel": "Species Details",
   "species.familyLabel": "Family",
   "species.familyDescription": "Other detected species in the same family.",
@@ -127,14 +118,12 @@
   "species.rarityLabel": "Rarity: {value}",
   "species.familyBadge": "Family: {value}",
   "species.fallbackDescription": "{commonName} ({scientificName}) is recorded at this location. An editorial description will be added soon.",
-
   "rarity.veryRare": "very rare",
   "rarity.rare": "rare",
   "rarity.uncommon": "uncommon",
   "rarity.common": "common",
   "rarity.veryCommon": "very common",
   "rarity.unknown": "unknown",
-
   "attribution.footer": "Images sourced from Wikipedia/Wikimedia. Licensed under the respective terms specified there.",
   "attribution.linkLabel": "Image Credits",
   "attribution.modalLabel": "Image Credits",
@@ -155,7 +144,6 @@
   "attribution.wikimediaLink": "Wikimedia/Wikipedia",
   "attribution.licenseText": "License Text",
   "attribution.photoOf": "Photo of {name}",
-
   "error.accessDenied": "Access to {service} was denied.",
   "error.notFound": "{service} could not find the requested data.",
   "error.tooManyRequests": "Too many requests to {service}. Please try again in a moment.",
@@ -168,5 +156,8 @@
   "error.archiveLoad": "Failed to load archive detections",
   "error.speciesLoad": "Failed to load species detections.",
   "error.speciesPhotoLoad": "Failed to load species photo",
-  "error.familyLoad": "Failed to load species in this family."
+  "error.familyLoad": "Failed to load species in this family.",
+  "errorBoundary.heading": "Something went wrong",
+  "errorBoundary.description": "An unexpected error occurred while rendering this view.",
+  "errorBoundary.reload": "Reload page"
 }


### PR DESCRIPTION
### Motivation
- Close out remaining review tasks by improving header navigation maintainability, strengthening API URL validation, and making the attribution modal and error surface more accessible and resilient.
- Raise unit-test coverage to meet repository thresholds and add deterministic test scaffolding for flaky paths.

### Description
- Replace duplicated navigation buttons with a mapped `navItems` config and lazy-initialize route state while normalizing the URL on mount in `src/App.tsx` to simplify view routing and avoid duplication.
- Add a reusable React `ErrorBoundary` (`src/components/ErrorBoundary.tsx`) and integrate it into the app with a localized fallback UI and reload action, and add unit tests for normal and error paths (`src/components/ErrorBoundary.test.tsx`).
- Improve attribution modal accessibility by adding ARIA attributes, initial focus and keyboard focus-trap (Escape-to-close and Tab wrapping), and wire refs for focus management in `src/App.tsx`, plus adjust landing card markup to avoid landmark conflicts in `src/features/landing/LandingView.tsx`.
- Harden `getApiBaseUrl` to validate http(s) values and add tests for missing/invalid values in `src/api/apiClient.test.ts`, stabilize E2E test time dependency (`e2e/support/mockBirdnet.ts`), and include the i18n safe token replacement fix and localized error-boundary strings.

### Testing
- Ran `npm run lint` and linting passed successfully.
- Ran `npm run test:coverage` and the full unit/integration suite passed (`64` tests passed) and coverage met repository thresholds (overall statements ~95.92% and lines ~95.84%).
- Built the production bundle with `npm run build` and the build completed successfully.
- Attempted E2E (`npm run test:e2e`) but Playwright browser installation is not available in this environment so E2E could not complete here (environment limitation, not a code regression).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a7f450e88328baac71f08b35d33b)