### PR TITLE
fix: resolve high-severity bugs from code review

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,6 +130,8 @@ const App = () => {
   const attributionCloseRef = useRef<HTMLButtonElement | null>(null)
   const creditsDialogRef = useRef<HTMLDivElement | null>(null)
   const creditsCloseRef = useRef<HTMLButtonElement | null>(null)
+  const routeStateRef = useRef<AppRouteState>({ view, lastMainView, selectedSpecies })
+  routeStateRef.current = { view, lastMainView, selectedSpecies }
 
   useBackgroundCacheWarmer(view === 'landing' || view === 'today')
 
@@ -153,8 +155,8 @@ const App = () => {
   }, [includeLocaleInRoute, locale])
 
   useEffect(() => {
-    updateHistory(initialState, 'replace')
-  }, [initialState, updateHistory])
+    updateHistory(routeStateRef.current, 'replace')
+  }, [updateHistory])
 
   useEffect(() => {
     const onAttributionUpdate = () => {

--- a/src/features/detections/ArchiveView.tsx
+++ b/src/features/detections/ArchiveView.tsx
@@ -66,7 +66,7 @@ const ArchiveView = ({ onSpeciesSelect, onAttributionOpen }: ArchiveViewProps) =
     const expectedStart = toDateInputValue(expectedStartDate)
     return startDate === expectedStart && endDate === expectedEnd
   }, [endDate, startDate, today])
-  const shouldUseSummary = isDefaultThirtyDayWindow && Boolean(summary && !summary.pending)
+  const shouldUseSummary = isDefaultThirtyDayWindow && minConfidence === 0 && Boolean(summary && !summary.pending)
 
   const { detections, isLoading, error, refresh } = useArchiveDetections(
     rangeStart,

--- a/src/features/detections/useArchiveDetections.ts
+++ b/src/features/detections/useArchiveDetections.ts
@@ -44,10 +44,10 @@ export const useArchiveDetections = (
   const startTime = rangeStart.valueOf()
   const endTime = rangeEnd.valueOf()
   const validRange = !Number.isNaN(startTime) && !Number.isNaN(endTime)
-  const startDate = validRange ? rangeStart.toISOString().slice(0, 10) : ''
-  const endDate = validRange
-    ? new Date(endTime - 1).toISOString().slice(0, 10)
-    : ''
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const toLocalDate = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+  const startDate = validRange ? toLocalDate(rangeStart) : ''
+  const endDate = validRange ? toLocalDate(new Date(endTime - 1)) : ''
   const mode = options.queryMode ?? 'range'
   const parallelBatchSize = Math.max(1, Math.floor(options.parallelBatchSize ?? 1))
 

--- a/src/features/detections/useBackgroundCacheWarmer.ts
+++ b/src/features/detections/useBackgroundCacheWarmer.ts
@@ -1,7 +1,5 @@
 import { useEffect } from 'react'
-
-const SUMMARY_WARM_URL = '/api/v2/summary/30d'
-const RECENT_WARM_URL = '/api/v2/detections/recent?limit=30'
+import { buildApiUrl } from '../../api/apiClient'
 
 export function useBackgroundCacheWarmer(enabled = true): void {
   useEffect(() => {
@@ -9,10 +7,11 @@ export function useBackgroundCacheWarmer(enabled = true): void {
       return
     }
 
+    const summaryUrl = buildApiUrl('/api/v2/summary/30d')
+    const recentUrl = buildApiUrl('/api/v2/detections/recent', new URLSearchParams({ limit: '30' }))
     const controller = new AbortController()
-    // Keep warm-up cheap: one summary call and one recent call.
-    void fetch(SUMMARY_WARM_URL, { signal: controller.signal, cache: 'no-store' }).catch(() => {})
-    void fetch(RECENT_WARM_URL, { signal: controller.signal, cache: 'no-store' }).catch(() => {})
+    void fetch(summaryUrl, { signal: controller.signal, cache: 'no-store' }).catch(() => {})
+    void fetch(recentUrl, { signal: controller.signal, cache: 'no-store' }).catch(() => {})
 
     return () => {
       controller.abort()

--- a/src/features/rarity/RarityView.test.tsx
+++ b/src/features/rarity/RarityView.test.tsx
@@ -94,7 +94,7 @@ describe('RarityView', () => {
     ).toBeInTheDocument()
   })
 
-  it('shows error state and retries via refresh callback', () => {
+  it('shows error state and retries via refresh callback when both summary and range fail', () => {
     const refresh = vi.fn().mockResolvedValue(undefined)
     mocks.useSummary30d.mockReturnValue({
       summary: null,
@@ -105,7 +105,7 @@ describe('RarityView', () => {
     mocks.useArchiveDetections.mockReturnValue({
       detections: [],
       isLoading: false,
-      error: null,
+      error: 'range failed',
       refresh,
     })
 
@@ -114,6 +114,24 @@ describe('RarityView', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'common.retry' }))
     expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show error when summary fails but range fallback succeeds', () => {
+    mocks.useSummary30d.mockReturnValue({
+      summary: null,
+      isLoading: false,
+      isPending: false,
+      error: 'summary failed',
+    })
+    mocks.useArchiveDetections.mockReturnValue({
+      detections: [],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+
+    renderWithQuery(<RarityView />)
+    expect(screen.queryByText('rarity.rangeError')).not.toBeInTheDocument()
   })
 
   it('shows empty highlights state when no notable matches exist', () => {

--- a/src/features/rarity/RarityView.tsx
+++ b/src/features/rarity/RarityView.tsx
@@ -144,7 +144,7 @@ const RarityView = ({ onSpeciesSelect, onAttributionOpen }: RarityViewProps) => 
   }, [notableMatches])
   const spotlightList = useMemo(() => notableList.slice(0, 10), [notableList])
   const effectiveIsLoading = (isSummaryLoading && !hasReadySummary) || isRangeLoading
-  const effectiveError = summaryError ?? rangeError
+  const effectiveError = summaryError ? rangeError : null
 
   if (effectiveIsLoading && !hasReadySummary && detections.length === 0 && !effectiveError) {
     return (


### PR DESCRIPTION
## Summary

- **ArchiveView confidence filter silent no-op**: When the 30-day summary path was active, `matchesFilter` was called without a confidence argument so confidence filtering was silently ignored. Fix: gate `shouldUseSummary` on `minConfidence === 0`, forcing the full range query when a confidence filter is active.

- **URL reset on locale toggle**: The `updateHistory` effect depended on `initialState` (a frozen snapshot) so toggling locale replaced the URL with the initial route, discarding any navigation the user had done. Fix: sync current route state into a ref each render; the effect reads from the ref so it always uses the live state.

- **useBackgroundCacheWarmer hardcoded paths**: Warm-up fetches used bare relative paths (`/api/v2/summary/30d`) bypassing `VITE_BIRDNET_API_BASE_URL` config and demo-mode intercept. Fix: replace with `buildApiUrl()`.

- **useArchiveDetections UTC date bug**: `toISOString().slice(0,10)` extracts UTC midnight, which is the previous calendar day in timezones west of UTC. Fix: build the date string from local `getFullYear`/`getMonth`/`getDate`.

- **RarityView stale error**: `effectiveError = summaryError ?? rangeError` would show the summary error even after the range fallback succeeded. Fix: `summaryError ? rangeError : null` — only surface an error when both paths have failed.

## Test plan

- [ ] `npm run build` passes (TypeScript + Vite)
- [ ] `npm test` — all 124 tests pass (added new test for the RarityView stale-error fix)
- [ ] `npm run lint` — clean