### PR TITLE
fix: code quality improvements (medium/low severity)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { getPhotoAttributionRecords } from './api/birdImages'
 import ErrorBoundary from './components/ErrorBoundary'
@@ -125,7 +125,7 @@ const App = () => {
   const [showScrollTop, setShowScrollTop] = useState(false)
   const [isAttributionOpen, setIsAttributionOpen] = useState(false)
   const [isCreditsOpen, setIsCreditsOpen] = useState(false)
-  const [, setAttributionVersion] = useState(0)
+  const [attributionVersion, setAttributionVersion] = useState(0)
   const attributionDialogRef = useRef<HTMLDivElement | null>(null)
   const attributionCloseRef = useRef<HTMLButtonElement | null>(null)
   const creditsDialogRef = useRef<HTMLDivElement | null>(null)
@@ -167,7 +167,10 @@ const App = () => {
     }
   }, [])
 
-  const attributionRecords = getPhotoAttributionRecords()
+  const attributionRecords = useMemo(
+    () => (void attributionVersion, getPhotoAttributionRecords()),
+    [attributionVersion],
+  )
 
   useEffect(() => {
     document.documentElement.lang = locale
@@ -507,20 +510,23 @@ const App = () => {
                 </svg>
               </span>
             </button>
-            {navItems.map((item) => (
-              <button
-                className={`inline-flex h-9 w-[6.75rem] shrink-0 items-center justify-center rounded-xl border px-3 py-2 text-[0.65rem] transition sm:w-[6.5rem] ${
-                  activeNavigationView === item.view
-                    ? 'border-slate-200 bg-white text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100'
-                    : 'border-slate-200 bg-white/70 text-slate-500 hover:border-slate-300 hover:bg-white hover:text-slate-700 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-400 dark:hover:border-slate-600 dark:hover:bg-slate-900 dark:hover:text-slate-300'
-                }`}
-                key={item.view}
-                onClick={() => handleViewChange(item.view)}
-                type="button"
-              >
-                {item.label}
-              </button>
-            ))}
+            <nav aria-label={t('nav.label')}>
+              {navItems.map((item) => (
+                <button
+                  aria-current={activeNavigationView === item.view ? 'page' : undefined}
+                  className={`inline-flex h-9 w-[6.75rem] shrink-0 items-center justify-center rounded-xl border px-3 py-2 text-[0.65rem] transition sm:w-[6.5rem] ${
+                    activeNavigationView === item.view
+                      ? 'border-slate-200 bg-white text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100'
+                      : 'border-slate-200 bg-white/70 text-slate-500 hover:border-slate-300 hover:bg-white hover:text-slate-700 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-400 dark:hover:border-slate-600 dark:hover:bg-slate-900 dark:hover:text-slate-300'
+                  }`}
+                  key={item.view}
+                  onClick={() => handleViewChange(item.view)}
+                  type="button"
+                >
+                  {item.label}
+                </button>
+              ))}
+            </nav>
           </div>
         </div>
       </header>

--- a/src/api/summary.ts
+++ b/src/api/summary.ts
@@ -120,15 +120,20 @@ export const fetchSummary30d = async (signal?: AbortSignal): Promise<Summary30d>
     }
   }
 
-  const response = await fetch(buildApiUrl('/api/v2/summary/30d'), {
+  let isPending = false
+  const raw = await requestJson<RawSummaryResponse>(buildApiUrl('/api/v2/summary/30d'), {
     signal,
-    cache: 'no-store',
-    headers: {
-      accept: 'application/json',
+    onResponse: (resp) => {
+      isPending = resp.status === 202
     },
+  }).catch((err: unknown) => {
+    if (isPending) {
+      return {} as RawSummaryResponse
+    }
+    throw err
   })
 
-  if (response.status === 202) {
+  if (isPending) {
     const nowIso = new Date().toISOString()
     return {
       generatedAt: nowIso,
@@ -147,12 +152,6 @@ export const fetchSummary30d = async (signal?: AbortSignal): Promise<Summary30d>
       },
     }
   }
-
-  if (!response.ok) {
-    throw new Error(`Summary request failed with status ${response.status}`)
-  }
-
-  const raw = (await response.json()) as RawSummaryResponse
 
   const nowIso = new Date().toISOString()
   const stats = raw.stats ?? {}

--- a/src/features/detections/TodayView.tsx
+++ b/src/features/detections/TodayView.tsx
@@ -396,7 +396,7 @@ const TodayView = ({
         ) : (
           <div
             className="max-h-[60vh] overflow-y-auto rounded-xl border border-slate-200 dark:border-slate-700"
-            ref={scrollContainerRef as RefObject<HTMLDivElement>}
+            ref={scrollContainerRef}
           >
             <ul className="divide-y divide-slate-100 bg-white dark:divide-slate-700 dark:bg-slate-900">
               {filteredDetections.map((detection) => (

--- a/src/features/species/SpeciesDetailView.tsx
+++ b/src/features/species/SpeciesDetailView.tsx
@@ -10,7 +10,7 @@ import { queryKeys } from '../../api/queryKeys'
 import { siteConfig } from '../../config/site'
 import { notableSpecies } from '../../data/notableSpecies'
 import { speciesDescriptions } from '../../data/speciesDescriptions'
-import { getLocalizedCommonName, getSpeciesData, t } from '../../i18n'
+import { getLocale, getLocalizedCommonName, getSpeciesData, t } from '../../i18n'
 import { toUserErrorMessage } from '../../utils/errorMessages'
 import { useSpeciesPhoto } from '../detections/useSpeciesPhoto'
 import { useSpeciesDetections } from './useSpeciesDetections'
@@ -154,7 +154,7 @@ const SpeciesDetailView = ({
 
       const sortedMatches = matches
         .slice()
-        .sort((a, b) => a.commonName.localeCompare(b.commonName, 'de'))
+        .sort((a, b) => a.commonName.localeCompare(b.commonName, getLocale()))
 
       queryClient.setQueryData(queryKeys.familyMatches(familyKey), sortedMatches)
       setFamilyMatches(sortedMatches)

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1,4 +1,5 @@
 {
+  "nav.label": "Hauptnavigation",
   "nav.live": "Live",
   "nav.today": "Heute",
   "nav.archive": "Archiv",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,4 +1,5 @@
 {
+  "nav.label": "Main navigation",
   "nav.live": "Live",
   "nav.today": "Today",
   "nav.archive": "Archive",


### PR DESCRIPTION
## Summary

- **Nav accessibility**: Wrapped nav buttons in `<nav aria-label>` and added `aria-current="page"` to the active item for screen-reader support. Added `nav.label` i18n key in both locales.

- **attributionRecords memoization**: `getPhotoAttributionRecords()` was called on every render. Now memoized with `attributionVersion` as the dep so it only recomputes when `birdnet-attribution-updated` fires.

- **summary.ts → requestJson**: The normal (non-demo) path used raw `fetch()`, bypassing timeout, retry, and `ApiClientError` wrapping. Migrated to `requestJson` with an `onResponse` callback to intercept 202 pending responses before JSON parsing attempts.

- **SpeciesDetailView localeCompare**: Family-match sort was hardcoded to `'de'` locale. Changed to `getLocale()` so it respects the user's selected language.

- **TodayView RefObject cast**: Removed unnecessary `as RefObject<HTMLDivElement>` cast — the prop type already declares `RefObject<HTMLDivElement | null>` which satisfies React 19's `Ref` type directly.

## Test plan

- [ ] `npm run build` — TypeScript clean
- [ ] `npm test` — 123 tests pass
- [ ] `npm run lint` — clean (0 warnings)