### PR TITLE
fix(security): upgrade libxml2 in Docker image (CVE-2026-6732)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN npm run build
 
 FROM nginx:alpine
 
-RUN apk add --no-cache nodejs libcap su-exec \
+RUN apk upgrade --no-cache \
+    && apk add --no-cache nodejs libcap su-exec \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

- Trivy security scan found CVE-2026-6732 (HIGH) in `libxml2 2.13.9-r0` on Alpine 3.23.4
- Fix available in `libxml2 2.13.9-r1`
- Adds `apk upgrade --no-cache` to the nginx runtime stage to pull in patched packages

## Test plan
- [ ] Security CI (container-image-scan) should pass after merge