### PR TITLE
fix(nightly): add json-summary coverage reporter so job summary populates

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     mockReset: true,
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'json-summary'],
       include: [
         'src/App.tsx',
         'src/api/apiClient.ts',


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `json-summary` to the vitest coverage reporters in `vitest.config.ts`

## Problem

The nightly `test-coverage` job reads `coverage/coverage-summary.json` to write the coverage table to the GitHub Job Summary. Without the `json-summary` reporter, vitest only emits `text` (console) and `html` outputs — the JSON file is never written, so the step always printed `No coverage data` and the summary table was blank.

Coverage itself was fine and all thresholds were passing (98.1% statements, 98.9% functions, 90.9% branches, 98.1% lines) — they just weren't visible in the Job Summary.

## Fix

```diff
-reporter: ['text', 'html'],
+reporter: ['text', 'html', 'json-summary'],
```

This makes vitest emit `coverage/coverage-summary.json` alongside the existing reporters, which the nightly workflow then reads to populate the summary table.

## Test plan

- [ ] After merge, verify the next nightly run shows a populated coverage table in the Job Summary
- [ ] Confirm all existing tests still pass (no functional change)

https://claude.ai/code/session_01F8tX34XeDzWJXV5X1KHCHa
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8tX34XeDzWJXV5X1KHCHa)_