### PR TITLE
fix: remediate HIGH undici CVEs (GHSA-vmh5-mc38-953g, GHSA-pr7r-676h-xcf6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3943,9 +3943,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
-      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- Bumps transitive dependency **undici 7.26.0 → 7.28.0** (via jsdom) to resolve two HIGH/moderate CVEs discovered in the daily security review
- Only `package-lock.json` changed; no production code or `package.json` was modified

## Vulnerabilities Fixed

| GHSA | Severity | Title |
|------|----------|-------|
| [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g) | **HIGH** (CVSS 7.4) | TLS certificate validation bypass via dropped `requestTls` in SOCKS5 ProxyAgent |
| [GHSA-pr7r-676h-xcf6](https://github.com/advisories/GHSA-pr7r-676h-xcf6) | moderate (CVSS 5.9) | Cross-user information disclosure via shared cache whitespace bypass |

`undici` is a `devDependency` — pulled in by `jsdom ^29.0.0` which requires `undici ^7.25.0`. The updated 7.28.0 satisfies that constraint.

## Verification

- `npm audit` → **0 vulnerabilities**
- `npm run lint` → clean
- `npm test` → **124/124 tests passing** across 20 test files

## Test plan
- [ ] CI passes (lint + unit tests + build)
- [ ] Security workflow shows 0 vulnerabilities after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtPD683JR27qMvFQjxcVkw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtPD683JR27qMvFQjxcVkw)_