### PR TITLE
chore: ignore coverage/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
## Summary
- Found during the daily dashboard health review: running `npm run test:coverage` locally leaves an untracked `coverage/` directory, which isn't in `.gitignore` (unlike `dist/` and `test-results/`, which already are).
- Adds `coverage` to `.gitignore` so the vitest coverage output doesn't show up as untracked/stray changes.

## Test plan
- N/A — `.gitignore`-only change, no runtime behavior affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_012TkD9S86Cf1vrNjJXXSaJL)_