### PR TITLE
chore: stop Dependabot from re-proposing an incompatible TypeScript 7 bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    ignore:
+      # @typescript-eslint (through at least 8.63.1-alpha, its canary) only
+      # supports typescript <6.1.0, so a TS major bump breaks `npm ci` via
+      # ERESOLVE. Remove once @typescript-eslint publishes TS 7 support.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Daily BirdNET Dashboard health review found CI red on Dependabot PR #187 (`typescript` 6.0.3 → 7.0.2): `npm ci` fails with `ERESOLVE` because `@typescript-eslint/eslint-plugin@8.63.0` requires `typescript >=4.8.4 <6.1.0`.
- Checked the npm registry directly: no published `@typescript-eslint` release — not even the `canary` tag (`8.63.1-alpha.8`) — supports TypeScript 7 yet, so this isn't a fixable-today conflict; forcing it through would break lint/build.
- Added a Dependabot `ignore` rule for `typescript` major-version updates so it stops recreating this broken PR every night. Closing #187 as a companion action — remove the ignore rule once `@typescript-eslint` ships TS 7 support.

## Review findings (last 24h)
- **nightly**: coverage 98.12% stmts / 90.9% branch / 98.98% funcs / 98.06% lines — all above the 95%/75% thresholds. Bundle unchanged (~447 KB total, JS 403.92 KB / CSS 42.79 KB gzip). E2E full suite 32/32 passed. Dependency health: 0 npm audit vulnerabilities, 2 outdated packages (`typescript`, `vite`).
- **ci**: nightly-scheduled run green; only failure was PR #187 (root-caused and addressed here).
- **security**: `vulnerability-audit` (npm audit) 0 vulnerabilities, `secret-scan` (gitleaks) no leaks, `container-image-scan` (Trivy on the Alpine 3.23.5 base image) 0 vulnerabilities.
- **renovate**: merged PR #188 (`vite` 8.1.3 → 8.1.4, clean patch bump, all checks green). PR #187 (Dependabot) closed as a genuine upstream incompatibility, not a code bug.

## Test plan
- [x] `.github/dependabot.yml` is valid YAML (reviewed by inspection)
- [x] Confirmed via `npm view @typescript-eslint/eslint-plugin@canary peerDependencies` that no release supports TypeScript 7
- [ ] Next Dependabot npm run should no longer propose a `typescript` major bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CrRwC88tKpkxxkw3w9aNQj)_