### PR TITLE
chore(deps): update dependency typescript to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.0.0",
     "jsdom": "^29.0.0",
-    "typescript": "^6.0.0",
+    "typescript": "^7.0.0",
     "vite": "^8.1.0",
     "vitest": "^4.0.18"
   }


### PR DESCRIPTION
Renovate prepared this update (`typescript` → v7) but the scheduled run aborted before opening a PR ("Repository has changed during renovation"). Opening it manually so CI can validate the major version bump.

Major version upgrades are permitted per repo policy. Will merge if CI (lint, tests, build, coverage, E2E) passes cleanly; otherwise will investigate breaking changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCB3BdQYSkghoAEc7hWQtS)_