### PR TITLE
security, a11y: sanitize wiki-sourced link URLs, add CSP to demo, focus on nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/bird-favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      HTTP-header CSP (see docker/nginx.conf) is the primary defense for
+      self-hosted deployments. This meta-tag copy covers hosts that can't set
+      custom response headers, like the GitHub Pages demo — frame-ancestors
+      and other header-only directives are dropped since browsers ignore them
+      here, but script-src/connect-src/img-src still provide real protection.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; base-uri 'self'; img-src 'self' data: https://upload.wikimedia.org https://commons.wikimedia.org; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https://de.wikipedia.org https://en.wikipedia.org https://commons.wikimedia.org https://upload.wikimedia.org; font-src 'self' data: https://fonts.gstatic.com; form-action 'self'"
+    />
     <title>BirdNET Dashboard</title>
   </head>
   <body>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -177,6 +177,16 @@ describe('App navigation and URL state', () => {
     expect(window.location.search).toBe('?view=landing')
   })
 
+  it('moves focus to the main content region on navigation, for screen-reader users', () => {
+    renderWithQuery(<App />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Archiv' }))
+    expect(document.activeElement).toBe(document.getElementById('main-content'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select Robin' }))
+    expect(document.activeElement).toBe(document.getElementById('main-content'))
+  })
+
   it('navigates to stats view via deep link and supports back navigation from species', () => {
     window.history.replaceState(null, '', '/?view=stats')
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,7 +130,15 @@ const App = () => {
   const attributionCloseRef = useRef<HTMLButtonElement | null>(null)
   const creditsDialogRef = useRef<HTMLDivElement | null>(null)
   const creditsCloseRef = useRef<HTMLButtonElement | null>(null)
+  const mainContentRef = useRef<HTMLElement | null>(null)
   const routeStateRef = useRef<AppRouteState>({ view, lastMainView, selectedSpecies })
+
+  // Moves focus (not just scroll) to the main content on navigation, so
+  // screen-reader users get an announcement that the view changed — sighted
+  // users already get that cue from the scroll-to-top below.
+  const focusMainContent = () => {
+    mainContentRef.current?.focus({ preventScroll: true })
+  }
   routeStateRef.current = { view, lastMainView, selectedSpecies }
 
   useBackgroundCacheWarmer(view === 'landing' || view === 'today')
@@ -250,6 +258,7 @@ const App = () => {
       'push',
     )
     window.scrollTo({ top: 0 })
+    focusMainContent()
   }
 
   const handleSpeciesSelect = (species: SelectedSpecies) => {
@@ -271,6 +280,7 @@ const App = () => {
       'push',
     )
     window.scrollTo({ top: 0 })
+    focusMainContent()
   }
 
   const handleSpeciesBack = () => {
@@ -285,6 +295,7 @@ const App = () => {
       'push',
     )
     window.scrollTo({ top: 0 })
+    focusMainContent()
   }
 
   useEffect(() => {
@@ -555,6 +566,8 @@ const App = () => {
       <main
         className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-4 py-5 sm:gap-10 sm:px-6 sm:py-10"
         id="main-content"
+        ref={mainContentRef}
+        tabIndex={-1}
       >
         {view === 'landing' ? (
           <LandingView

--- a/src/api/birdImages.test.ts
+++ b/src/api/birdImages.test.ts
@@ -275,6 +275,43 @@ describe('birdImages', () => {
     expect(photo?.sourceUrl).toBe('https://en.wikipedia.org/wiki/Example')
   })
 
+  it('drops unsafe (non-http/https) URLs from Wikipedia/Commons metadata instead of exposing them as link hrefs', async () => {
+    requestJsonMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('https://de.wikipedia.org/api/rest_v1/page/summary/')) {
+        return {
+          thumbnail: { source: 'https://upload.wikimedia.org/unsafe-test.jpg', width: 400, height: 300 },
+          content_urls: { desktop: { page: 'javascript:alert(1)' } },
+        }
+      }
+      if (url.includes('piprop=name')) {
+        return { query: { pages: { '1': { pageimage: 'Unsafe.jpg' } } } }
+      }
+      if (url.includes('iiprop=url')) {
+        return {
+          query: {
+            pages: {
+              '1': {
+                imageinfo: [
+                  {
+                    descriptionurl: 'javascript:alert(document.cookie)',
+                    extmetadata: { LicenseUrl: { value: 'data:text/html,<script>alert(1)</script>' } },
+                  },
+                ],
+              },
+            },
+          },
+        }
+      }
+      return {}
+    })
+
+    const { fetchSpeciesPhoto } = await import('./birdImages')
+    const photo = await fetchSpeciesPhoto({ scientificName: 'Unsafe species' })
+
+    expect(photo?.sourceUrl).toBe('')
+    expect(photo?.attribution?.licenseUrl).toBeUndefined()
+  })
+
   it('sorts attribution records by common name, then scientific name', async () => {
     requestJsonMock.mockResolvedValue({})
 

--- a/src/api/birdImages.ts
+++ b/src/api/birdImages.ts
@@ -176,6 +176,23 @@ const normalizeName = (value?: string): string => {
 const buildCacheKey = (commonName: string, scientificName: string): string =>
   `${commonName}|${scientificName}`
 
+// Wikipedia/Commons metadata (description URLs, license URLs) is wiki-editable
+// content, not a trusted first-party value. It ends up in an <a href> in the
+// UI, so reject anything that isn't a plain http(s) link (e.g. a javascript:
+// URI) before it ever reaches the DOM.
+const toSafeHttpUrl = (value?: string): string | undefined => {
+  if (!value) {
+    return undefined
+  }
+
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
 const toCommonsFileTitleFromThumbnailUrl = (thumbnailUrl: string): string | null => {
   try {
     const parsed = new URL(thumbnailUrl)
@@ -287,11 +304,11 @@ const resolveAttribution = async (
     }
 
     return {
-      sourceUrl: info.descriptionurl ?? fallbackSourceUrl,
+      sourceUrl: toSafeHttpUrl(info.descriptionurl) ?? fallbackSourceUrl,
       author: stripHtml(info.extmetadata?.Artist?.value),
       credit: stripHtml(info.extmetadata?.Credit?.value),
       license: stripHtml(info.extmetadata?.LicenseShortName?.value),
-      licenseUrl: info.extmetadata?.LicenseUrl?.value,
+      licenseUrl: toSafeHttpUrl(info.extmetadata?.LicenseUrl?.value),
       usageTerms: stripHtml(info.extmetadata?.UsageTerms?.value),
     }
   }
@@ -346,8 +363,8 @@ const fetchSummaryThumbnail = async (
     }
 
     const sourceUrl =
-      data.content_urls?.desktop?.page ??
-      data.content_urls?.mobile?.page ??
+      toSafeHttpUrl(data.content_urls?.desktop?.page) ??
+      toSafeHttpUrl(data.content_urls?.mobile?.page) ??
       ''
 
     const imageTitleFromPage = await resolveImageTitle(


### PR DESCRIPTION
## Summary

A follow-up safety/accessibility audit (no High findings — this codebase is already well-hardened: existing CSP for Docker deploys, a real focus-trapped modal, bounded caches, rate-limited nginx proxy) turned up three concrete, worth-fixing gaps:

**1. Unsanitized wiki-sourced URLs flowing into `<a href>`**
- `photo.sourceUrl` and `photo.attribution.licenseUrl` come from Wikipedia/Commons API responses (`descriptionurl`, `extmetadata.LicenseUrl.value`) — wiki-editable content, not a trusted first-party value — and were used directly as link `href`s with no protocol check.
- Adds `toSafeHttpUrl()` in `src/api/birdImages.ts`, applied at all three points API responses become `SpeciesPhoto`/attribution data, rejecting anything that isn't a plain `http(s)` link (e.g. a `javascript:` URI) before it ever reaches the DOM.

**2. No CSP on the public GitHub Pages demo**
- The self-hosted Docker deployment already ships a solid CSP via `docker/nginx.conf` (`script-src 'self'`, restricted `img-src`/`connect-src`, etc.), but the public demo (`demo-pages.yml` → GitHub Pages) had none, since GH Pages can't set custom response headers.
- Adds a matching `<meta http-equiv="Content-Security-Policy">` to `index.html`. Header-only directives like `frame-ancestors` are dropped since browsers ignore them via `<meta>` anyway — full clickjacking protection still requires the Docker/nginx path — but `script-src`/`connect-src`/`img-src` now provide real protection on the demo too.

**3. No focus management on view navigation**
- Clicking a nav item or a species card only scrolled the page to top; focus stayed wherever it was, so screen-reader users got no cue that the view had changed (sighted users could see the scroll).
- Adds a `mainContentRef` + `tabIndex={-1}` on `#main-content` and focuses it after each of the three navigation paths (view change, species select, species back) in `src/App.tsx`.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test:coverage` — statements 95.93%, branches 84.59%, functions 98.91%, lines 95.83% (all above threshold)
- [x] `npm run build` — succeeds
- [x] `npx playwright test` (full suite, 38 tests including visual-regression) — all passing, confirming the new CSP `<meta>` doesn't break font loading, inline styles, or any API/image fetches
- [x] Added a unit test for `toSafeHttpUrl` (rejecting `javascript:`/`data:` URLs from mocked Wikipedia/Commons responses) and a unit test asserting focus lands on `#main-content` after navigation


---
_Generated by [Claude Code](https://claude.ai/code/session_01EFFvSifnPGA4gv5uqGxRLA)_