### PR TITLE
fix(deps): pin brace-expansion to 5.0.7 to remediate GHSA-3jxr-9vmj-r5cp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,9 @@
         "typescript": "^6.0.0",
         "vite": "^8.1.5",
         "vitest": "^4.0.18"
+      },
+      "overrides": {
+        "brace-expansion": "^5.0.7"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2090,9 +2093,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "react-dom": "^19.2.4",
     "tailwindcss": "^4.3.3"
   },
+  "overrides": {
+    "brace-expansion": "^5.0.7"
+  },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Summary
- The `security` workflow's `vulnerability-audit` job (`npm audit --audit-level=high`) started failing on 2026-07-21: a HIGH severity DoS vulnerability was found in `brace-expansion@5.0.6` ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)), a transitive dependency pulled in via `eslint -> minimatch`. It's also flagged as Dependabot alert [#24](https://github.com/CoffeeKanzler/birdnet-dashboard/security/dependabot/24).
- Pin `brace-expansion` to `^5.0.7` (the patched release) via a `package.json` `overrides` entry, and update the corresponding `package-lock.json` entry to match.
- This same failure was blocking CI on the 4 open Dependabot PRs (#205–#208), since it's a pre-existing issue on `main`, not something introduced by those bumps.

## Test plan
- [x] `npm ci` — clean install succeeds
- [x] `npm audit --audit-level=high` — 0 vulnerabilities (was 1 high)
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds, bundle size unchanged (404.17 kB / gzip 117.12 kB, matches latest nightly report)
- [x] `npm test` — 228/228 tests passing across 32 files

🤖 Generated as part of the daily automated repo health-check routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_0127NS76HAZkwpSvPfTwmLU6)_