### PR TITLE
fix(security): patch brace-expansion DoS vulnerability (GHSA-rgw5-rvv9-x895)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -889,9 +889,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -907,9 +904,6 @@
       "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -927,9 +921,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -945,9 +936,6 @@
       "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -965,9 +953,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -983,9 +968,6 @@
       "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2221,9 +2203,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4381,9 +4363,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4403,9 +4382,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4427,9 +4403,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4449,9 +4422,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "tailwindcss": "^4.3.3"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.0",


### PR DESCRIPTION
## Summary
- Daily repo health review found a newly-disclosed high-severity npm advisory: `brace-expansion` 5.0.8 (transitive via `eslint` → `minimatch`) is vulnerable to a DoS via unbounded intermediate arrays ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)). This wasn't present in yesterday's nightly `security` run — it was disclosed after that scan.
- Bumped the existing `overrides.brace-expansion` pin from `^5.0.8` to `^5.0.9`, where the fix landed, and refreshed the lockfile via `npm audit fix` / `npm install`.
- The other vulnerability seen locally (`postcss` moderate, [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp)) was already resolved by the `vite` 8.1.5 → 8.2.0 Dependabot bump (#221), which pulled in a patched `postcss`.
- `npm audit` now reports **0 vulnerabilities**.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test:coverage` — 228/228 tests pass, coverage unchanged (95.93% stmts / 84.59% branches / 98.91% funcs / 95.83% lines — all above the 95%/75% thresholds)
- [x] `npm run build` — succeeds, bundle size unchanged (~449 kB total, no size regression)
- [x] `npm audit` — 0 vulnerabilities

---
_Generated by [Claude Code](https://claude.ai/code/session_0198CPnkfu2tkVRAah8SoL8R)_