### PR TITLE
fix(security): patch nanoid indefinite-loop vulnerability (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3469,9 +3469,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Daily automated review found `npm audit` flagging **1 HIGH severity vulnerability**: `nanoid <3.3.17` (transitive dependency via `postcss` → `vite`), which can loop indefinitely when given a zero size ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)).
- Fixed with `npm audit fix`, which bumped `nanoid` `3.3.16` → `3.3.18`. No other dependency or `package.json` changes were needed — `postcss`'s existing semver range already allows the patched version.
- `npm audit` now reports 0 vulnerabilities.

## Test plan
- [x] `npm run lint` — passes
- [x] `npm run test:coverage` — 228/228 tests pass; coverage unchanged (95.93% stmts / 84.59% branch / 98.91% funcs / 95.83% lines, all above thresholds)
- [x] `npm run build` — succeeds, bundle size unchanged (404.21 kB JS / 42.94 kB CSS)
- [x] `npm audit` — 0 vulnerabilities


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZvRY2xdBcg3i8H7yPxGrh)_